### PR TITLE
Add Tag component

### DIFF
--- a/lib/surface_bulma/tag.ex
+++ b/lib/surface_bulma/tag.ex
@@ -1,0 +1,45 @@
+defmodule SurfaceBulma.Tag do
+  @moduledoc """
+  Tag is very useful as a way to attach information to a block or other component. Its size makes
+  it also easy to display in numbers, making it appropriate for long lists of items.
+  """
+
+  use Surface.Component
+
+  @doc "The label of the tag, when no content (default slot) is provided"
+  property label, :string
+
+  @doc "The color of the tag"
+  property color, :string,
+    values: ~w(black dark light white primary link info success warning danger)
+
+  @doc "The size of the delete"
+  property size, :string, values: ~w(normal medium large)
+
+  @doc "Light style"
+  property light, :boolean
+
+  @doc "Rounded style"
+  property rounded, :boolean
+
+  @doc """
+  The content of the generated `<span>` element. If no content is provided,
+  the value of property `label` is used instead.
+  """
+  slot default
+
+  def render(assigns) do
+    ~H"""
+    <span
+      class={{
+        "tag",
+        "is-#{@color}": @color,
+        "is-#{@size}": @size,
+        "is-light": @light,
+        "is-rounded": @rounded
+      }}>
+      <slot>{{ @label }}</slot>
+    </span>
+    """
+  end
+end

--- a/test/surface_bulma/tag_test.exs
+++ b/test/surface_bulma/tag_test.exs
@@ -1,0 +1,78 @@
+defmodule Surface.Components.TagTest do
+  use ExUnit.Case, async: true
+
+  alias SurfaceBulma.Tag, warn: false
+  import ComponentTestHelper
+
+  test "create a tag" do
+    code = """
+    <Tag>tag</Tag>
+    """
+
+    assert render_live(code) =~ """
+           <span class="tag">
+           tag
+           </span>
+           """
+  end
+
+  test "create a tag according to the given label" do
+    code = """
+    <Tag label="tag" />
+    """
+
+    assert render_live(code) =~ """
+           <span class="tag">
+             tag
+           </span>
+           """
+  end
+
+  test "property color" do
+    code = """
+    <Tag label="tag" color="primary" />
+    """
+
+    assert render_live(code) =~ """
+           <span class="tag is-primary">
+             tag
+           </span>
+           """
+  end
+
+  test "property size" do
+    code = """
+    <Tag label="tag" size="normal" />
+    """
+
+    assert render_live(code) =~ """
+           <span class="tag is-normal">
+             tag
+           </span>
+           """
+  end
+
+  test "property light" do
+    code = """
+    <Tag label="tag" color="primary" light />
+    """
+
+    assert render_live(code) =~ """
+           <span class="tag is-primary is-light">
+             tag
+           </span>
+           """
+  end
+
+  test "property rounded" do
+    code = """
+    <Tag label="tag" color="primary" rounded />
+    """
+
+    assert render_live(code) =~ """
+           <span class="tag is-primary is-rounded">
+             tag
+           </span>
+           """
+  end
+end


### PR DESCRIPTION
This PR adds bulma tag element:

https://bulma.io/documentation/elements/tag/

Examples:

```Elixir
 <Tag label="tag" />
 <Tag>tag</Tag>
 <Tag color="primary">tag</Tag>
 <Tag color="primary" light>tag</Tag>
 <Tag color="primary" light size="large">tag</Tag>
 <Tag color="primary" rounded size="large">tag</Tag>
```

I'm skipping the [is-delete](https://bulma.io/documentation/elements/tag/#modifiers) modifier since it can be achieved (with different style though) using `Delete` component. I can include though if you think it will be good to have 🙌 